### PR TITLE
Feature BL-21719 remove laminas logging replace with DVSA Logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ dummy.php
 .tags*
 review/
 .phpunit.result.cache
-/data
+data/logs/*

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dummy.php
 .tags*
 review/
 .phpunit.result.cache
+/data

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ composer require dvsa/mot-cpms-client
              );
    
    * ```version```          : This is the version of CPMS API to target, currently on version 1
-   * ```logger_alias```     : Zend Service Manager alias for retrieving a  instance
+   * ```logger_alias```     : Zend Service Manager alias for retrieving a Monolog Logger instance
    * ```identity_provider``` : This is the service manager alias that should return an object which implements ```CpmsClient\Authenticate\IdentityProviderInterface```. 
    This is mandatory. The following information is retrieved from the class
    

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ composer require dvsa/mot-cpms-client
              );
    
    * ```version```          : This is the version of CPMS API to target, currently on version 1
-   * ```logger_alias```     : Zend Service Manager alias for retrieving a Laminas\Log instance
+   * ```logger_alias```     : Zend Service Manager alias for retrieving a  instance
    * ```identity_provider``` : This is the service manager alias that should return an object which implements ```CpmsClient\Authenticate\IdentityProviderInterface```. 
    This is mandatory. The following information is retrieved from the class
    

--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,11 @@
         "dvsa/mot-cpms-notifications": "^3.0.0",
         "laminas/laminas-mvc": "^3.3.0",
         "laminas/laminas-cache": "^3.12.0",
-        "laminas/laminas-log": "^2.13",
         "laminas/laminas-filter": "^2.13",
-        "laminas/laminas-dependency-plugin": "^2.6.0",
         "laminas/laminas-cache-storage-adapter-filesystem": "^2.0",
         "laminas/laminas-cache-storage-adapter-memory": "^2.0",
-        "laminas/laminas-cache-storage-adapter-apcu": "^2.5.0"
+        "laminas/laminas-cache-storage-adapter-apcu": "^2.5.0",
+        "dvsa/mot-logger": "^3.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
@@ -41,7 +40,6 @@
     "config": {
         "allow-plugins": {
             "laminas/laminas-component-installer": true,
-            "laminas/laminas-dependency-plugin": true,
             "captainhook/plugin-composer": true
         }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3117d62e3d83de4b370c70b13218814e",
+    "content-hash": "cdf368c2756b1ad8a06d7bd031433068",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -212,26 +212,26 @@
         },
         {
             "name": "brick/varexporter",
-            "version": "0.3.8",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/varexporter.git",
-                "reference": "b5853edea6204ff8fa10633c3a4cccc4058410ed"
+                "reference": "2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/varexporter/zipball/b5853edea6204ff8fa10633c3a4cccc4058410ed",
-                "reference": "b5853edea6204ff8fa10633c3a4cccc4058410ed",
+                "url": "https://api.github.com/repos/brick/varexporter/zipball/2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb",
+                "reference": "2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.0",
-                "php": "^7.2 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "php-coveralls/php-coveralls": "^2.2",
                 "phpunit/phpunit": "^8.5 || ^9.0",
-                "vimeo/psalm": "4.23.0"
+                "vimeo/psalm": "5.15.0"
             },
             "type": "library",
             "autoload": {
@@ -249,7 +249,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/varexporter/issues",
-                "source": "https://github.com/brick/varexporter/tree/0.3.8"
+                "source": "https://github.com/brick/varexporter/tree/0.4.0"
             },
             "funding": [
                 {
@@ -257,7 +257,161 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-21T23:05:38+00:00"
+            "time": "2023-09-01T21:10:07+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "4.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "61e730f1658814821a85f2402c945f3883407dec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/61e730f1658814821a85f2402c945f3883407dec",
+                "reference": "61e730f1658814821a85f2402c945f3883407dec",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1.5",
+                "php": "^8.2",
+                "psr/cache": "^1|^2|^3",
+                "psr/log": "^1|^2|^3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "14.0.0",
+                "fig/log-test": "^1",
+                "jetbrains/phpstorm-stubs": "2023.2",
+                "phpstan/phpstan": "2.1.30",
+                "phpstan/phpstan-phpunit": "2.0.7",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "11.5.50",
+                "slevomat/coding-standard": "8.27.1",
+                "squizlabs/php_codesniffer": "4.0.1",
+                "symfony/cache": "^6.3.8|^7.0|^8.0",
+                "symfony/console": "^5.4|^6.3|^7.0|^8.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "db2",
+                "dbal",
+                "mariadb",
+                "mssql",
+                "mysql",
+                "oci8",
+                "oracle",
+                "pdo",
+                "pgsql",
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/dbal/issues",
+                "source": "https://github.com/doctrine/dbal/tree/4.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-20T08:52:12+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=14"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
+            },
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "dvsa/mot-cpms-notifications",
@@ -339,6 +493,65 @@
                 "source": "https://github.com/dvsa/mot-cpms-queues/tree/v3.0.0"
             },
             "time": "2024-07-17T14:36:28+00:00"
+        },
+        {
+            "name": "dvsa/mot-logger",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dvsa/mot-logger.git",
+                "reference": "c028a81ac6722c5e78871655ccadb160b375c17a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dvsa/mot-logger/zipball/c028a81ac6722c5e78871655ccadb160b375c17a",
+                "reference": "c028a81ac6722c5e78871655ccadb160b375c17a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^3.5 || ^4.0",
+                "ext-json": "*",
+                "laminas/laminas-eventmanager": "^3.15",
+                "laminas/laminas-modulemanager": "^2.16",
+                "laminas/laminas-mvc": "^3.8",
+                "laminas/laminas-router": "^3.7",
+                "monolog/monolog": "^3.10",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "captainhook/captainhook": "^5.16",
+                "captainhook/plugin-composer": "^5.3",
+                "dvsa/coding-standards": "^2.0",
+                "phpstan/phpstan": "^1.11",
+                "phpunit/phpunit": "^9.6",
+                "squizlabs/php_codesniffer": "^3.10",
+                "vimeo/psalm": "^5.24"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DvsaLogger\\": "src/"
+                },
+                "classmap": [
+                    "./Module.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Unified logging utility for DVSA MOT applications, powered by Monolog.",
+            "keywords": [
+                "MOT",
+                "dvsa",
+                "logging",
+                "monolog"
+            ],
+            "support": {
+                "issues": "https://github.com/dvsa/mot-logger/issues",
+                "source": "https://github.com/dvsa/mot-logger/tree/v3.3.0"
+            },
+            "time": "2026-04-14T10:03:49+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -967,22 +1180,22 @@
         },
         {
             "name": "laminas/laminas-config",
-            "version": "3.9.0",
+            "version": "3.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-config.git",
-                "reference": "e53717277f6c22b1c697a46473b9a5ec9a438efa"
+                "reference": "b816433bd36ddc4ba93e190eaac18497b0b6948c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-config/zipball/e53717277f6c22b1c697a46473b9a5ec9a438efa",
-                "reference": "e53717277f6c22b1c697a46473b9a5ec9a438efa",
+                "url": "https://api.github.com/repos/laminas/laminas-config/zipball/b816433bd36ddc4ba93e190eaac18497b0b6948c",
+                "reference": "b816433bd36ddc4ba93e190eaac18497b0b6948c",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "laminas/laminas-stdlib": "^3.6",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
+                "php": "^8.1.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
@@ -990,11 +1203,11 @@
                 "zendframework/zend-config": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.4.0",
-                "laminas/laminas-filter": "~2.23.0",
-                "laminas/laminas-i18n": "~2.19.0",
-                "laminas/laminas-servicemanager": "~3.19.0",
-                "phpunit/phpunit": "~9.5.25"
+                "laminas/laminas-coding-standard": "^3.0.1",
+                "laminas/laminas-filter": "^2.39.0",
+                "laminas/laminas-i18n": "^2.29.0",
+                "laminas/laminas-servicemanager": "^3.23.0",
+                "phpunit/phpunit": "^10.5.38"
             },
             "suggest": {
                 "laminas/laminas-filter": "^2.7.2; install if you want to use the Filter processor",
@@ -1031,90 +1244,37 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-09-19T12:02:54+00:00"
-        },
-        {
-            "name": "laminas/laminas-dependency-plugin",
-            "version": "2.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-dependency-plugin.git",
-                "reference": "d98c34fc81f65564ef97e045a381ac3419958615"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-dependency-plugin/zipball/d98c34fc81f65564ef97e045a381ac3419958615",
-                "reference": "d98c34fc81f65564ef97e045a381ac3419958615",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": ">=1.1.0 <2.3.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0"
-            },
-            "require-dev": {
-                "composer/composer": ">=1.9.0 <2.3.0",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "mikey179/vfsstream": "^1.6.11",
-                "phpunit/phpunit": "^9.5.5",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "roave/security-advisories": "dev-master",
-                "vimeo/psalm": "^4.5"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Laminas\\DependencyPlugin\\DependencyRewriterPluginDelegator"
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\DependencyPlugin\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Replace zendframework and zfcampus packages with their Laminas Project equivalents.",
-            "support": {
-                "issues": "https://github.com/laminas/laminas-dependency-plugin/issues",
-                "source": "https://github.com/laminas/laminas-dependency-plugin/tree/2.6.0"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2023-12-14T20:02:33+00:00"
+            "abandoned": true,
+            "time": "2026-01-29T12:14:07+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
-            "version": "2.13.0",
+            "version": "2.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-escaper.git",
-                "reference": "af459883f4018d0f8a0c69c7a209daef3bf973ba"
+                "reference": "06f211dfffff18d91844c1f55250d5d13c007e18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/af459883f4018d0f8a0c69c7a209daef3bf973ba",
-                "reference": "af459883f4018d0f8a0c69c7a209daef3bf973ba",
+                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/06f211dfffff18d91844c1f55250d5d13c007e18",
+                "reference": "06f211dfffff18d91844c1f55250d5d13c007e18",
                 "shasum": ""
             },
             "require": {
                 "ext-ctype": "*",
                 "ext-mbstring": "*",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "conflict": {
                 "zendframework/zend-escaper": "*"
             },
             "require-dev": {
-                "infection/infection": "^0.27.0",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "maglnet/composer-require-checker": "^3.8.0",
-                "phpunit/phpunit": "^9.6.7",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.9"
+                "infection/infection": "^0.31.0",
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
             },
             "type": "library",
             "autoload": {
@@ -1146,37 +1306,40 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-10-10T08:35:13+00:00"
+            "time": "2025-10-14T18:31:13+00:00"
         },
         {
             "name": "laminas/laminas-eventmanager",
-            "version": "3.11.0",
+            "version": "3.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-eventmanager.git",
-                "reference": "9cfa79ce247c567f05ce4b7c975c6bdf9698c5dd"
+                "reference": "90b4bd33264629af8e39caf5aa83473ac03aa04c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/9cfa79ce247c567f05ce4b7c975c6bdf9698c5dd",
-                "reference": "9cfa79ce247c567f05ce4b7c975c6bdf9698c5dd",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/90b4bd33264629af8e39caf5aa83473ac03aa04c",
+                "reference": "90b4bd33264629af8e39caf5aa83473ac03aa04c",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0"
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "conflict": {
                 "container-interop/container-interop": "<1.2",
                 "zendframework/zend-eventmanager": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-stdlib": "^3.15",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
+                "amphp/dns": "^2.2",
+                "amphp/socket": "^2.3.1",
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "laminas/laminas-stdlib": "^3.20",
+                "phpbench/phpbench": "^1.3.1",
+                "phpunit/phpunit": "^10.5.58",
+                "psalm/plugin-phpunit": "^0.19.0",
                 "psr/container": "^1.1.2 || ^2.0.2",
-                "vimeo/psalm": "^5.0.0"
+                "sebastian/recursion-context": "^5.0.1",
+                "vimeo/psalm": "^6.13"
             },
             "suggest": {
                 "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature",
@@ -1214,7 +1377,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-10-10T08:29:58+00:00"
+            "time": "2025-10-31T10:29:01+00:00"
         },
         {
             "name": "laminas/laminas-filter",
@@ -1296,32 +1459,32 @@
         },
         {
             "name": "laminas/laminas-http",
-            "version": "2.18.0",
+            "version": "2.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-http.git",
-                "reference": "76de9008f889bc7088f85a41d0d2b06c2b59c53d"
+                "reference": "9462fc84330d25b23383823831380abb33907fdd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-http/zipball/76de9008f889bc7088f85a41d0d2b06c2b59c53d",
-                "reference": "76de9008f889bc7088f85a41d0d2b06c2b59c53d",
+                "url": "https://api.github.com/repos/laminas/laminas-http/zipball/9462fc84330d25b23383823831380abb33907fdd",
+                "reference": "9462fc84330d25b23383823831380abb33907fdd",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-loader": "^2.8",
+                "laminas/laminas-loader": "^2.10",
                 "laminas/laminas-stdlib": "^3.6",
-                "laminas/laminas-uri": "^2.9.1",
-                "laminas/laminas-validator": "^2.15",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "laminas/laminas-uri": "^2.14",
+                "laminas/laminas-validator": "^2.15 || ^3.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "conflict": {
                 "zendframework/zend-http": "*"
             },
             "require-dev": {
                 "ext-curl": "*",
-                "laminas/laminas-coding-standard": "~2.4.0",
-                "phpunit/phpunit": "^9.5.25"
+                "laminas/laminas-coding-standard": "^3.0.1",
+                "phpunit/phpunit": "^10.5.38"
             },
             "suggest": {
                 "paragonie/certainty": "For automated management of cacert.pem"
@@ -1357,31 +1520,31 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-11-23T15:45:41+00:00"
+            "time": "2025-12-05T11:02:08+00:00"
         },
         {
             "name": "laminas/laminas-json",
-            "version": "3.5.0",
+            "version": "3.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-json.git",
-                "reference": "7a8a1d7bf2d05dd6c1fbd7c0868d3848cf2b57ec"
+                "reference": "5448d357c4520d79f5caf4d46a1fe03ec8b8e4b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-json/zipball/7a8a1d7bf2d05dd6c1fbd7c0868d3848cf2b57ec",
-                "reference": "7a8a1d7bf2d05dd6c1fbd7c0868d3848cf2b57ec",
+                "url": "https://api.github.com/repos/laminas/laminas-json/zipball/5448d357c4520d79f5caf4d46a1fe03ec8b8e4b0",
+                "reference": "5448d357c4520d79f5caf4d46a1fe03ec8b8e4b0",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "^8.1.0"
             },
             "conflict": {
                 "zendframework/zend-json": "*"
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.4.0",
-                "laminas/laminas-stdlib": "^2.7.7 || ^3.1",
+                "laminas/laminas-stdlib": "^2.7.7 || ^3.19",
                 "phpunit/phpunit": "^9.5.25"
             },
             "suggest": {
@@ -1418,24 +1581,25 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-10-17T04:06:45+00:00"
+            "abandoned": true,
+            "time": "2026-01-23T11:10:11+00:00"
         },
         {
             "name": "laminas/laminas-loader",
-            "version": "2.9.0",
+            "version": "2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-loader.git",
-                "reference": "51ed9c3fa42d1098a9997571730c0cbf42d078d3"
+                "reference": "ec8cee33fb254ee4d9c8e8908c870e5c797e1272"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/51ed9c3fa42d1098a9997571730c0cbf42d078d3",
-                "reference": "51ed9c3fa42d1098a9997571730c0cbf42d078d3",
+                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/ec8cee33fb254ee4d9c8e8908c870e5c797e1272",
+                "reference": "ec8cee33fb254ee4d9c8e8908c870e5c797e1272",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "^8.0.0"
             },
             "conflict": {
                 "zendframework/zend-loader": "*"
@@ -1474,129 +1638,45 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-10-16T12:50:49+00:00"
-        },
-        {
-            "name": "laminas/laminas-log",
-            "version": "2.16.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-log.git",
-                "reference": "a9c16bb161311553238b8989aa587bed4b518a7e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-log/zipball/a9c16bb161311553238b8989aa587bed4b518a7e",
-                "reference": "a9c16bb161311553238b8989aa587bed4b518a7e",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-servicemanager": "^3.3.0",
-                "laminas/laminas-stdlib": "^3.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
-                "psr/log": "^1.1.2"
-            },
-            "conflict": {
-                "zendframework/zend-log": "*"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0.0"
-            },
-            "require-dev": {
-                "ext-dom": "*",
-                "ext-json": "*",
-                "ext-xml": "*",
-                "firephp/firephp-core": "^0.5.3",
-                "laminas/laminas-coding-standard": "~2.3.0",
-                "laminas/laminas-db": "^2.6",
-                "laminas/laminas-escaper": "^2.5",
-                "laminas/laminas-filter": "^2.5",
-                "laminas/laminas-mail": "^2.6.1",
-                "laminas/laminas-validator": "^2.10.1",
-                "mikey179/vfsstream": "^1.6.7",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5.10"
-            },
-            "suggest": {
-                "ext-mongo": "mongo extension to use Mongo writer",
-                "ext-mongodb": "mongodb extension to use MongoDB writer",
-                "laminas/laminas-db": "Laminas\\Db component to use the database log writer",
-                "laminas/laminas-escaper": "Laminas\\Escaper component, for use in the XML log formatter",
-                "laminas/laminas-mail": "Laminas\\Mail component to use the email log writer",
-                "laminas/laminas-validator": "Laminas\\Validator component to block invalid log messages"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "component": "Laminas\\Log",
-                    "config-provider": "Laminas\\Log\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Log\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Robust, composite logger with filtering, formatting, and PSR-3 support",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "log",
-                "logging"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-log/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-log/issues",
-                "rss": "https://github.com/laminas/laminas-log/releases.atom",
-                "source": "https://github.com/laminas/laminas-log"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2022-12-19T16:38:15+00:00"
+            "abandoned": true,
+            "time": "2025-12-30T11:30:39+00:00"
         },
         {
             "name": "laminas/laminas-modulemanager",
-            "version": "2.14.0",
+            "version": "2.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-modulemanager.git",
-                "reference": "fb0a2c34423f7d3321dd7c42dc5fc4db905a99ac"
+                "reference": "4b14617df01be6c83ac62fdb689427f8ed56d9c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-modulemanager/zipball/fb0a2c34423f7d3321dd7c42dc5fc4db905a99ac",
-                "reference": "fb0a2c34423f7d3321dd7c42dc5fc4db905a99ac",
+                "url": "https://api.github.com/repos/laminas/laminas-modulemanager/zipball/4b14617df01be6c83ac62fdb689427f8ed56d9c1",
+                "reference": "4b14617df01be6c83ac62fdb689427f8ed56d9c1",
                 "shasum": ""
             },
             "require": {
-                "brick/varexporter": "^0.3.2",
+                "brick/varexporter": "^0.3.2 || ^0.4 || ^0.5 || ^0.6",
                 "laminas/laminas-config": "^3.7",
                 "laminas/laminas-eventmanager": "^3.4",
                 "laminas/laminas-stdlib": "^3.6",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
                 "webimpress/safe-writer": "^1.0.2 || ^2.1"
             },
             "conflict": {
+                "amphp/amp": "<2.6.4",
                 "zendframework/zend-modulemanager": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.3",
-                "laminas/laminas-loader": "^2.9.0",
-                "laminas/laminas-mvc": "^3.5.0",
-                "laminas/laminas-servicemanager": "^3.19.0",
-                "phpunit/phpunit": "^9.5.25",
-                "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.29"
+                "amphp/dns": "^1.24 || ^2.1.2",
+                "amphp/socket": "^1.2.1 || ^2.3.1",
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "laminas/laminas-loader": "^2.11",
+                "laminas/laminas-mvc": "^3.7.0",
+                "laminas/laminas-servicemanager": "^3.23.0",
+                "phpunit/phpunit": "^10.5.38",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
             },
             "suggest": {
                 "laminas/laminas-console": "Laminas\\Console component",
@@ -1634,42 +1714,40 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-10-28T09:21:04+00:00"
+            "time": "2025-10-17T18:22:00+00:00"
         },
         {
             "name": "laminas/laminas-mvc",
-            "version": "3.6.1",
+            "version": "3.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-mvc.git",
-                "reference": "f12e801c31c04a4b35017354ff84070f5573879f"
+                "reference": "53ba28b7222d3a3b49747a26babef43d1b17fb6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-mvc/zipball/f12e801c31c04a4b35017354ff84070f5573879f",
-                "reference": "f12e801c31c04a4b35017354ff84070f5573879f",
+                "url": "https://api.github.com/repos/laminas/laminas-mvc/zipball/53ba28b7222d3a3b49747a26babef43d1b17fb6f",
+                "reference": "53ba28b7222d3a3b49747a26babef43d1b17fb6f",
                 "shasum": ""
             },
             "require": {
                 "container-interop/container-interop": "^1.2",
                 "laminas/laminas-eventmanager": "^3.4",
                 "laminas/laminas-http": "^2.15",
-                "laminas/laminas-modulemanager": "^2.8",
+                "laminas/laminas-modulemanager": "^2.16",
                 "laminas/laminas-router": "^3.11.1",
                 "laminas/laminas-servicemanager": "^3.20.0",
-                "laminas/laminas-stdlib": "^3.6",
-                "laminas/laminas-view": "^2.14",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "laminas/laminas-stdlib": "^3.19",
+                "laminas/laminas-view": "^2.18.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
             },
             "conflict": {
                 "zendframework/zend-mvc": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.4.0",
-                "laminas/laminas-json": "^3.3",
-                "phpspec/prophecy": "^1.15.0",
-                "phpspec/prophecy-phpunit": "^2.0.1",
-                "phpunit/phpunit": "^9.5.25",
+                "laminas/laminas-coding-standard": "^2.5.0",
+                "laminas/laminas-json": "^3.6",
+                "phpunit/phpunit": "^10.5.38",
                 "webmozart/assert": "^1.11"
             },
             "suggest": {
@@ -1715,37 +1793,39 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-03-15T10:21:03+00:00"
+            "time": "2024-11-18T00:14:29+00:00"
         },
         {
             "name": "laminas/laminas-router",
-            "version": "3.11.1",
+            "version": "3.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-router.git",
-                "reference": "3512c28cb4ffd64a62bc9e8b685a50a6547b0a11"
+                "reference": "e9a3dcf704cfc2ea47da6c2275409c2187034f8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-router/zipball/3512c28cb4ffd64a62bc9e8b685a50a6547b0a11",
-                "reference": "3512c28cb4ffd64a62bc9e8b685a50a6547b0a11",
+                "url": "https://api.github.com/repos/laminas/laminas-router/zipball/e9a3dcf704cfc2ea47da6c2275409c2187034f8f",
+                "reference": "e9a3dcf704cfc2ea47da6c2275409c2187034f8f",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-http": "^2.15",
                 "laminas/laminas-servicemanager": "^3.14.0",
                 "laminas/laminas-stdlib": "^3.10.1",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "laminas/laminas-uri": "^2.14",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/container": "^1 || ^2.0.2"
             },
             "conflict": {
                 "zendframework/zend-router": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.4.0",
-                "laminas/laminas-i18n": "^2.19.0",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.0.0"
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "laminas/laminas-http": "^2.22",
+                "laminas/laminas-i18n": "^2.31.0",
+                "phpunit/phpunit": "^11.5.43",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
             },
             "suggest": {
                 "laminas/laminas-i18n": "^2.15.0 if defining translatable HTTP path segments"
@@ -1786,25 +1866,25 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-29T14:47:23+00:00"
+            "time": "2026-03-02T14:54:55+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.22.0",
+            "version": "3.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "b4f547078af2ac3173cbe4a64e8fdfbd626c77ae"
+                "reference": "b172a0df568bf37ebdfb3658263156eefe3c1e8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/b4f547078af2ac3173cbe4a64e8fdfbd626c77ae",
-                "reference": "b4f547078af2ac3173cbe4a64e8fdfbd626c77ae",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/b172a0df568bf37ebdfb3658263156eefe3c1e8c",
+                "reference": "b172a0df568bf37ebdfb3658263156eefe3c1e8c",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-stdlib": "^3.17",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "laminas/laminas-stdlib": "^3.19",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
@@ -1821,15 +1901,15 @@
             },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.11.99.5",
-                "friendsofphp/proxy-manager-lts": "^1.0.14",
-                "laminas/laminas-code": "^4.10.0",
+                "friendsofphp/proxy-manager-lts": "^1.0.18",
+                "laminas/laminas-code": "^4.16.0",
                 "laminas/laminas-coding-standard": "~2.5.0",
                 "laminas/laminas-container-config-test": "^0.8",
-                "mikey179/vfsstream": "^1.6.11",
-                "phpbench/phpbench": "^1.2.9",
-                "phpunit/phpunit": "^10.4",
+                "mikey179/vfsstream": "^1.6.12",
+                "phpbench/phpbench": "^1.4.1",
+                "phpunit/phpunit": "^10.5.58",
                 "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.8.0"
+                "vimeo/psalm": "^5.26.1"
             },
             "suggest": {
                 "friendsofphp/proxy-manager-lts": "ProxyManager ^2.1.1 to handle lazy initialization of services"
@@ -1876,34 +1956,34 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-10-10T21:23:36+00:00"
+            "time": "2025-10-14T09:03:51+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.18.0",
+            "version": "3.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "e85b29076c6216e7fc98e72b42dbe1bbc3b95ecf"
+                "reference": "b1c81514cfe158aadf724c42b34d3d0a8164c096"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/e85b29076c6216e7fc98e72b42dbe1bbc3b95ecf",
-                "reference": "e85b29076c6216e7fc98e72b42dbe1bbc3b95ecf",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/b1c81514cfe158aadf724c42b34d3d0a8164c096",
+                "reference": "b1c81514cfe158aadf724c42b34d3d0a8164c096",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "conflict": {
                 "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.5",
-                "phpbench/phpbench": "^1.2.14",
-                "phpunit/phpunit": "^10.3.3",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.15.0"
+                "laminas/laminas-coding-standard": "^3.1.0",
+                "phpbench/phpbench": "^1.4.1",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
             },
             "type": "library",
             "autoload": {
@@ -1935,33 +2015,33 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-09-19T10:15:21+00:00"
+            "time": "2025-10-11T18:13:12+00:00"
         },
         {
             "name": "laminas/laminas-uri",
-            "version": "2.10.0",
+            "version": "2.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-uri.git",
-                "reference": "663b050294945c7345cc3a61f3ca661d5f9e1f80"
+                "reference": "e804288f4540988903dc0ede386ce5eec87198df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-uri/zipball/663b050294945c7345cc3a61f3ca661d5f9e1f80",
-                "reference": "663b050294945c7345cc3a61f3ca661d5f9e1f80",
+                "url": "https://api.github.com/repos/laminas/laminas-uri/zipball/e804288f4540988903dc0ede386ce5eec87198df",
+                "reference": "e804288f4540988903dc0ede386ce5eec87198df",
                 "shasum": ""
             },
             "require": {
                 "laminas/laminas-escaper": "^2.9",
-                "laminas/laminas-validator": "^2.15",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "laminas/laminas-validator": "^2.39 || ^3.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "conflict": {
                 "zendframework/zend-uri": "*"
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.4.0",
-                "phpunit/phpunit": "^9.5.25"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "autoload": {
@@ -1993,26 +2073,26 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-10-16T15:02:45+00:00"
+            "time": "2025-12-05T10:02:11+00:00"
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.39.0",
+            "version": "2.65.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "cec22e6f55fa68ec24e21c4f021fc1b2c3783c49"
+                "reference": "f0767ca83e0dd91a6f8ccdd4f0887eb132c0ea49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/cec22e6f55fa68ec24e21c4f021fc1b2c3783c49",
-                "reference": "cec22e6f55fa68ec24e21c4f021fc1b2c3783c49",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/f0767ca83e0dd91a6f8ccdd4f0887eb132c0ea49",
+                "reference": "f0767ca83e0dd91a6f8ccdd4f0887eb132c0ea49",
                 "shasum": ""
             },
             "require": {
                 "laminas/laminas-servicemanager": "^3.21.0",
-                "laminas/laminas-stdlib": "^3.13",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "laminas/laminas-stdlib": "^3.19",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
                 "psr/http-message": "^1.0.1 || ^2.0.0"
             },
             "conflict": {
@@ -2020,16 +2100,16 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "^2.5",
-                "laminas/laminas-db": "^2.18",
-                "laminas/laminas-filter": "^2.32",
-                "laminas/laminas-i18n": "^2.23",
-                "laminas/laminas-session": "^2.16",
-                "laminas/laminas-uri": "^2.10.0",
-                "phpunit/phpunit": "^10.3.3",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "psr/http-client": "^1.0.2",
-                "psr/http-factory": "^1.0.2",
-                "vimeo/psalm": "^5.15"
+                "laminas/laminas-db": "^2.20",
+                "laminas/laminas-filter": "^2.41.0",
+                "laminas/laminas-i18n": "^2.30.0",
+                "laminas/laminas-session": "^2.25.1",
+                "laminas/laminas-uri": "^2.13.0",
+                "phpunit/phpunit": "^10.5.58",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "psr/http-client": "^1.0.3",
+                "psr/http-factory": "^1.1.0",
+                "vimeo/psalm": "^5.26.1"
             },
             "suggest": {
                 "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
@@ -2077,20 +2157,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-09-06T20:51:34+00:00"
+            "time": "2025-10-13T14:40:30+00:00"
         },
         {
             "name": "laminas/laminas-view",
-            "version": "2.30.0",
+            "version": "2.44.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-view.git",
-                "reference": "055623fd0634f2ab2a51defa03c22ddee4e89df7"
+                "reference": "93f5c8b52af2603f1aa494f1c98ce2013baff18e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-view/zipball/055623fd0634f2ab2a51defa03c22ddee4e89df7",
-                "reference": "055623fd0634f2ab2a51defa03c22ddee4e89df7",
+                "url": "https://api.github.com/repos/laminas/laminas-view/zipball/93f5c8b52af2603f1aa494f1c98ce2013baff18e",
+                "reference": "93f5c8b52af2603f1aa494f1c98ce2013baff18e",
                 "shasum": ""
             },
             "require": {
@@ -2102,34 +2182,36 @@
                 "laminas/laminas-json": "^3.3",
                 "laminas/laminas-servicemanager": "^3.21.0",
                 "laminas/laminas-stdlib": "^3.10.1",
-                "php": "~8.1.0 || ~8.2.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
                 "psr/container": "^1 || ^2"
             },
             "conflict": {
+                "amphp/dns": "<2.1.2",
+                "amphp/socket": "<2.3.1",
                 "container-interop/container-interop": "<1.2",
                 "laminas/laminas-router": "<3.0.1",
                 "laminas/laminas-session": "<2.12",
                 "zendframework/zend-view": "*"
             },
             "require-dev": {
-                "laminas/laminas-authentication": "^2.13",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-feed": "^2.20",
-                "laminas/laminas-filter": "^2.32",
-                "laminas/laminas-http": "^2.18",
-                "laminas/laminas-i18n": "^2.23",
-                "laminas/laminas-modulemanager": "^2.14",
-                "laminas/laminas-mvc": "^3.6.1",
-                "laminas/laminas-mvc-i18n": "^1.7",
-                "laminas/laminas-mvc-plugin-flashmessenger": "^1.9",
-                "laminas/laminas-navigation": "^2.18.1",
-                "laminas/laminas-paginator": "^2.17",
-                "laminas/laminas-permissions-acl": "^2.15",
-                "laminas/laminas-router": "^3.11.1",
-                "laminas/laminas-uri": "^2.10",
-                "phpunit/phpunit": "^10.1.3",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.12"
+                "laminas/laminas-authentication": "^2.18",
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "laminas/laminas-feed": "^2.25.0",
+                "laminas/laminas-filter": "^2.41",
+                "laminas/laminas-http": "^2.22",
+                "laminas/laminas-i18n": "^2.30.0",
+                "laminas/laminas-modulemanager": "^2.18",
+                "laminas/laminas-mvc": "^3.8.0",
+                "laminas/laminas-mvc-i18n": "^1.9",
+                "laminas/laminas-mvc-plugin-flashmessenger": "^1.11.0",
+                "laminas/laminas-navigation": "^2.21.0",
+                "laminas/laminas-paginator": "^2.20.0",
+                "laminas/laminas-permissions-acl": "^2.17",
+                "laminas/laminas-router": "^3.14.0",
+                "laminas/laminas-uri": "^2.13",
+                "phpunit/phpunit": "^10.5.58",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
             },
             "suggest": {
                 "laminas/laminas-authentication": "Laminas\\Authentication component",
@@ -2177,7 +2259,110 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-08-17T10:28:59+00:00"
+            "time": "2025-11-17T01:59:08+00:00"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "3.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8 || ^2.0",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "php-console/php-console": "^3.1.8",
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^10.5.17 || ^11.0.7",
+                "predis/predis": "^1.1 || ^2",
+                "rollbar/rollbar": "^4.0",
+                "ruflin/elastica": "^7 || ^8",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-02T08:56:05+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
@@ -2247,35 +2432,30 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.17.1",
+            "version": "v4.19.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d"
+                "reference": "51bd93cc741b7fc3d63d20b6bdcd99fdaa359837"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
-                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/51bd93cc741b7fc3d63d20b6bdcd99fdaa359837",
+                "reference": "51bd93cc741b7fc3d63d20b6bdcd99fdaa359837",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=7.0"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/php-parse"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.9-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "PhpParser\\": "lib/PhpParser"
@@ -2297,9 +2477,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.17.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.5"
             },
-            "time": "2023-08-13T19:53:39+00:00"
+            "time": "2025-12-06T11:45:25+00:00"
         },
         {
             "name": "psr/cache",
@@ -2500,20 +2680,20 @@
         },
         {
             "name": "psr/http-factory",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "e616d01114759c4c489f93b099585439f795fe35"
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
-                "reference": "e616d01114759c4c489f93b099585439f795fe35",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0",
+                "php": ">=7.1",
                 "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
@@ -2537,7 +2717,7 @@
                     "homepage": "https://www.php-fig.org/"
                 }
             ],
-            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
             "keywords": [
                 "factory",
                 "http",
@@ -2549,9 +2729,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
+                "source": "https://github.com/php-fig/http-factory"
             },
-            "time": "2023-04-10T20:10:41+00:00"
+            "time": "2024-04-15T12:06:14+00:00"
         },
         {
             "name": "psr/http-message",
@@ -2608,30 +2788,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.4",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2652,9 +2832,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -7099,12 +7279,12 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/config/application.config.php
+++ b/config/application.config.php
@@ -2,7 +2,6 @@
 return array(
     'modules' => array(
         'Laminas\Filter',
-        'Laminas\Log',
         'Laminas\Cache',
         'Laminas\Router',
         'Laminas\Validator',

--- a/config/autoload/cpms-client.global.php
+++ b/config/autoload/cpms-client.global.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'cpms_client' => [
+        'logger' => [
+            'location' => 'data/logs',
+            'filename' => 'cpms-client.log',
+            'channel' => 'cpms-client',
+        ],
+    ],
+];
+

--- a/src/CpmsClient/Client/HttpRestJsonClient.php
+++ b/src/CpmsClient/Client/HttpRestJsonClient.php
@@ -6,7 +6,6 @@ use CpmsClient\Utility\Util;
 use Laminas\Http\Client as HttpClient;
 use Laminas\Http\Headers;
 use Laminas\Http\Request;
-use Laminas\Log\Logger;
 use Laminas\Stdlib\Parameters;
 use Psr\Log\LoggerInterface;
 
@@ -32,7 +31,7 @@ class HttpRestJsonClient
 
     /**
      * @param HttpClient $httpClient
-     * @param Logger     $logger
+     * @param LoggerInterface $logger
      * @param Request    $request
      */
     public function __construct(HttpClient $httpClient, LoggerInterface $logger, Request $request = null)

--- a/src/CpmsClient/Client/HttpRestJsonClient.php
+++ b/src/CpmsClient/Client/HttpRestJsonClient.php
@@ -17,28 +17,15 @@ use Psr\Log\LoggerInterface;
 class HttpRestJsonClient
 {
     const CONTENT_TYPE_FORMAT = 'application/vnd.dvsa-gov-uk.v%d%s; charset=UTF-8';
-    /** @var \Laminas\Http\Client */
-    protected $httpClient;
 
     /** @var \CpmsClient\Client\ClientOptions */
     protected $options;
 
-    /** @var \Laminas\Http\Request */
-    protected $request;
-
-    /** @var  \Psr\Log\LoggerInterface */
-    protected $logger;
-
-    /**
-     * @param HttpClient $httpClient
-     * @param LoggerInterface $logger
-     * @param Request    $request
-     */
-    public function __construct(HttpClient $httpClient, LoggerInterface $logger, Request $request = null)
-    {
-        $this->setHttpClient($httpClient);
-        $this->setRequest($request);
-        $this->logger = $logger;
+    public function __construct(
+        protected HttpClient $httpClient,
+        protected LoggerInterface $logger,
+        protected ?Request $request = null
+    ) {
     }
 
     /**
@@ -77,7 +64,7 @@ class HttpRestJsonClient
         //Log request header
         $this->logger->debug($request->toString());
 
-        /** @var $response \Laminas\Http\Response */
+        /** @var \Laminas\Http\Response $response */
         $response = $this->getHttpClient()->dispatch($request);
 
         //log response code

--- a/src/CpmsClient/Client/HttpRestJsonClient.php
+++ b/src/CpmsClient/Client/HttpRestJsonClient.php
@@ -16,15 +16,15 @@ use Psr\Log\LoggerInterface;
  */
 class HttpRestJsonClient
 {
-    const CONTENT_TYPE_FORMAT = 'application/vnd.dvsa-gov-uk.v%d%s; charset=UTF-8';
+    private const CONTENT_TYPE_FORMAT = 'application/vnd.dvsa-gov-uk.v%d%s; charset=UTF-8';
 
     /** @var \CpmsClient\Client\ClientOptions */
-    protected $options;
+    private ?ClientOptions $options = null;
 
     public function __construct(
-        protected HttpClient $httpClient,
-        protected LoggerInterface $logger,
-        protected ?Request $request = null
+        private readonly HttpClient $httpClient,
+        private readonly LoggerInterface $logger,
+        private readonly ?Request $request = null
     ) {
     }
 

--- a/src/CpmsClient/Client/HttpRestJsonClient.php
+++ b/src/CpmsClient/Client/HttpRestJsonClient.php
@@ -8,7 +8,7 @@ use Laminas\Http\Headers;
 use Laminas\Http\Request;
 use Laminas\Log\Logger;
 use Laminas\Stdlib\Parameters;
-use Laminas\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class HttpRestJsonClient
@@ -27,7 +27,7 @@ class HttpRestJsonClient
     /** @var \Laminas\Http\Request */
     protected $request;
 
-    /** @var  \Laminas\Log\Logger */
+    /** @var  \Psr\Log\LoggerInterface */
     protected $logger;
 
     /**
@@ -90,7 +90,7 @@ class HttpRestJsonClient
         $decodedData = \json_decode($response->getBody(), true);
 
         if (empty($decodedData)) {
-            $this->logger->warn($response->getBody());
+            $this->logger->warning($response->getBody());
 
             return $response->getBody();
         }

--- a/src/CpmsClient/Client/NotificationsClient.php
+++ b/src/CpmsClient/Client/NotificationsClient.php
@@ -6,7 +6,6 @@ use DVSA\CPMS\Queues\QueueAdapters\Interfaces\Queues;
 use DVSA\CPMS\Queues\QueueAdapters\Values\QueueMessage;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
-use Laminas\Log\Logger;
 
 class NotificationsClient
 {

--- a/src/CpmsClient/Client/NotificationsClient.php
+++ b/src/CpmsClient/Client/NotificationsClient.php
@@ -4,7 +4,7 @@ namespace CpmsClient\Client;
 
 use DVSA\CPMS\Queues\QueueAdapters\Interfaces\Queues;
 use DVSA\CPMS\Queues\QueueAdapters\Values\QueueMessage;
-use Laminas\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Laminas\Log\Logger;
 
@@ -21,7 +21,7 @@ class NotificationsClient
      *
      * @param Queues $queuesClient
      *        how we will talk to our queues
-     * @param Logger $logger
+     * @param LoggerInterface $logger
      *        how we will report on what happens
      */
     public function __construct(

--- a/src/CpmsClient/Client/NotificationsClient.php
+++ b/src/CpmsClient/Client/NotificationsClient.php
@@ -10,47 +10,35 @@ use RuntimeException;
 class NotificationsClient
 {
     /**
-     * in our config, what is the name of the queue we need to read
+     * In our config, what is the name of the queue we need to read
      * new notifications from?
      */
     const NOTIFICATIONS_QUEUENAME = "notifications";
 
     /**
-     * our constructor
-     *
      * @param Queues $queuesClient
      *        how we will talk to our queues
      * @param LoggerInterface $logger
      *        how we will report on what happens
      */
     public function __construct(
-        protected Queues $queuesClient,
-        public LoggerInterface $logger
+        private readonly Queues $queuesClient,
+        private readonly LoggerInterface $logger
     ) {
     }
 
     /**
-     * get the next batch of messages from the notifications queue
-     *
-     * if there are no messages, this will return an empty list
-     *
-     * @return array
+     * Get the next batch of messages from the notifications queue
+     * if there are no messages, this will return an empty list.
      */
-    public function getNotifications()
+    public function getNotifications(): array
     {
-        // shorthand
+
         $queuesClient = $this->queuesClient;
-
-        // what are we doing?
         $this->logger->debug("reading messages from queue: " . self::NOTIFICATIONS_QUEUENAME);
-
-        // get our next messages
         $qMessages = $queuesClient->receiveMessagesFromQueue(self::NOTIFICATIONS_QUEUENAME);
-
-        // decode them
         $notificationsArray = [];
         foreach ($qMessages as $qMessage) {
-            // robustness!
             $notification = $qMessage->getPayload();
             if (!is_object($notification)) {
                 throw new RuntimeException("non-object received from notifications queue");
@@ -61,20 +49,18 @@ class NotificationsClient
             ];
         }
 
-        // all done
         $this->logger->debug("read " . count($notificationsArray) . " message(s) from queue: " . self::NOTIFICATIONS_QUEUENAME);
         return $notificationsArray;
     }
 
     /**
-     * confirm that a message can be dropped from the queue that it
-     * came from
+     * Confirm that a message can be dropped from the queue that it
+     * came from.
      *
      * @param  QueueMessage $metadata
      *         the metadata message that we're done with
-     * @return void
      */
-    public function confirmMessageHandled(QueueMessage $metadata)
+    public function confirmMessageHandled(QueueMessage $metadata): void
     {
         $this->queuesClient->confirmMessageHandled($metadata);
     }
@@ -89,10 +75,8 @@ class NotificationsClient
      * returns the client we are using to talk to our queues
      *
      * mainly here to help with unit testing
-     *
-     * @return Queues
      */
-    public function getQueuesClient()
+    public function getQueuesClient(): Queues
     {
         return $this->queuesClient;
     }

--- a/src/CpmsClient/Client/NotificationsClientFactory.php
+++ b/src/CpmsClient/Client/NotificationsClientFactory.php
@@ -3,7 +3,7 @@
 namespace CpmsClient\Client;
 
 use CpmsClient\Service\LoggerFactory;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 class NotificationsClientFactory implements FactoryInterface

--- a/src/CpmsClient/Client/RestClientFactory.php
+++ b/src/CpmsClient/Client/RestClientFactory.php
@@ -2,7 +2,7 @@
 namespace CpmsClient\Client;
 
 use CpmsClient\Service\LoggerFactory;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\Http\Client;
 use Laminas\Http\Client as HttpClient;
 use Laminas\Http\Request;

--- a/src/CpmsClient/Controller/Plugin/GetApiDomain.php
+++ b/src/CpmsClient/Controller/Plugin/GetApiDomain.php
@@ -1,7 +1,7 @@
 <?php
 namespace CpmsClient\Controller\Plugin;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\Mvc\Controller\AbstractRestfulController;
 use Laminas\Mvc\Controller\Plugin\AbstractPlugin;
 

--- a/src/CpmsClient/Controller/Plugin/GetRestClient.php
+++ b/src/CpmsClient/Controller/Plugin/GetRestClient.php
@@ -1,7 +1,7 @@
 <?php
 namespace CpmsClient\Controller\Plugin;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\Mvc\Controller\Plugin\AbstractPlugin;
 

--- a/src/CpmsClient/Factory/GetApiDomainFactory.php
+++ b/src/CpmsClient/Factory/GetApiDomainFactory.php
@@ -4,7 +4,7 @@ namespace CpmsClient\Factory;
 
 
 use CpmsClient\Controller\Plugin\GetApiDomain;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Interop\Container\Exception\ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;

--- a/src/CpmsClient/Factory/GetRestClientFactory.php
+++ b/src/CpmsClient/Factory/GetRestClientFactory.php
@@ -4,7 +4,7 @@ namespace CpmsClient\Factory;
 
 
 use CpmsClient\Controller\Plugin\GetRestClient;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Interop\Container\Exception\ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;

--- a/src/CpmsClient/Service/ApiDomainServiceFactory.php
+++ b/src/CpmsClient/Service/ApiDomainServiceFactory.php
@@ -2,7 +2,7 @@
 namespace CpmsClient\Service;
 
 use CpmsClient\Utility\Util;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\Http\Request;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 

--- a/src/CpmsClient/Service/ApiService.php
+++ b/src/CpmsClient/Service/ApiService.php
@@ -10,8 +10,7 @@ use CpmsClient\Utility\Util;
 use DVSA\CPMS\Queues\QueueAdapters\Values\QueueMessage;
 use Exception;
 use Laminas\Http\Request;
-use Laminas\Log\Logger;
-use Laminas\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class ApiService
@@ -315,7 +314,7 @@ class ApiService
                 }
                 $token = new AccessToken($data);
             } else {
-                $this->getLogger()->warn('Unable to create access token with data: ' . print_r($data, true));
+                $this->getLogger()->warning('Unable to create access token with data: ' . print_r($data, true));
 
                 return $data;
             }
@@ -420,7 +419,7 @@ class ApiService
         }
 
         if ($logger = $this->getLogger()) {
-            $logger->err(implode(' ', $message));
+            $logger->error(implode(' ', $message));
         }
 
         return array(
@@ -452,7 +451,7 @@ class ApiService
     /**
      * Set logger object
      *
-     * @param Logger $logger
+     * @param LoggerInterface $logger
      *
      * @return mixed
      */
@@ -466,7 +465,7 @@ class ApiService
     /**
      * Get logger object
      *
-     * @return  Logger
+     * @return  LoggerInterface
      */
     public function getLogger()
     {
@@ -548,7 +547,7 @@ class ApiService
         $response = $this->put("/api/notifications/" . $message->getNotificationId() . '/acknowledged', 'NOTIFICATION', []);
         if (!isset($response['code']) || $response['code'] !== self::CPMS_CODE_SUCCESS) {
             $msg = "response from HttpClient does not contain expected 'code' field";
-            $this->logger->warn($msg, $response);
+            $this->logger->warning($msg, $response);
             throw new CpmsNotificationAcknowledgementFailed($msg, $response);
         }
 

--- a/src/CpmsClient/Service/ApiService.php
+++ b/src/CpmsClient/Service/ApiService.php
@@ -421,7 +421,7 @@ class ApiService
         if ($logger = $this->getLogger()) {
             $logger->error(implode(' ', $message));
         }
-
+   
         return array(
             'code'    => 105,
             'message' => sprintf("An CPMS client error occurred, ID %s\n%s", $errorId, implode('\n', $message)),

--- a/src/CpmsClient/Service/ApiServiceFactory.php
+++ b/src/CpmsClient/Service/ApiServiceFactory.php
@@ -4,7 +4,7 @@ namespace CpmsClient\Service;
 use CpmsClient\Authenticate\IdentityProviderInterface;
 use CpmsClient\Client\HttpRestJsonClient;
 use CpmsClient\Client\NotificationsClient;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**

--- a/src/CpmsClient/Service/CacheAwareApiService.php
+++ b/src/CpmsClient/Service/CacheAwareApiService.php
@@ -2,7 +2,8 @@
 namespace CpmsClient\Service;
 
 use Laminas\Cache\Storage\StorageInterface;
-use Laminas\Log\LoggerAwareTrait;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 
 /**
  * Class ApiService
@@ -13,9 +14,9 @@ use Laminas\Log\LoggerAwareTrait;
  *
  * @package CpmsClient\Service
  */
-class CacheAwareApiService
+class CacheAwareApiService implements LoggerAwareInterface
 {
-    use LoggerAwareTrait;
+     use LoggerAwareTrait;
     /**
      * @var ApiService
      */

--- a/src/CpmsClient/Service/CacheAwareApiServiceFactory.php
+++ b/src/CpmsClient/Service/CacheAwareApiServiceFactory.php
@@ -1,6 +1,6 @@
 <?php
 namespace CpmsClient\Service;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 

--- a/src/CpmsClient/Service/LoggerFactory.php
+++ b/src/CpmsClient/Service/LoggerFactory.php
@@ -30,9 +30,15 @@ class LoggerFactory implements FactoryInterface
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): LoggerInterface
     {
         $config = $container->get('config');
-        $filename = $this->getLogFilename($config);
 
-        $logger = new Logger('cpms-client');
+        $loggerConfig = $config['cpms_client']['logger'] ?? [];
+
+        $filename = rtrim($loggerConfig['location'] ?? 'data/logs', '/') . '/'
+            . trim($loggerConfig['filename'] ?? 'cpms-client.log', '/');
+
+        $channel = $loggerConfig['channel'] ?? 'cpms-client';
+
+        $logger = new Logger($channel);
         $logger->pushHandler(new StreamHandler($filename));
 
         return $logger;
@@ -50,7 +56,7 @@ class LoggerFactory implements FactoryInterface
         if (isset($config['logPath']) and is_file($config['logPath'])) {
             $filename = $config['logPath'];
         } else {
-            $filename = rtrim($config['logger']['location'], '/') . '/' . trim($config['logger']['filename'], '/');
+            $filename = rtrim($config['cpms_client']['logger']['location'], '/') . '/' . trim($config['cpms_client']['logger']['filename'], '/');
         }
 
         return $filename;

--- a/src/CpmsClient/Service/LoggerFactory.php
+++ b/src/CpmsClient/Service/LoggerFactory.php
@@ -21,13 +21,13 @@ class LoggerFactory implements FactoryInterface
      *
      * @param ContainerInterface $container
      *
-     * @param $requestedName
+     * @param mixed $requestedName
      * @param array|null $options
      * @return LoggerInterface
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \Psr\Container\NotFoundExceptionInterface
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): LoggerInterface
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): LoggerInterface
     {
         $config = $container->get('config');
 

--- a/src/CpmsClient/Service/LoggerFactory.php
+++ b/src/CpmsClient/Service/LoggerFactory.php
@@ -1,7 +1,7 @@
 <?php
 namespace CpmsClient\Service;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;

--- a/src/CpmsClient/Service/LoggerFactory.php
+++ b/src/CpmsClient/Service/LoggerFactory.php
@@ -2,9 +2,10 @@
 namespace CpmsClient\Service;
 
 use Interop\Container\ContainerInterface;
-use Laminas\Log\Logger;
-use Laminas\Log\Writer\Stream;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class LoggerFactory
@@ -22,17 +23,17 @@ class LoggerFactory implements FactoryInterface
      *
      * @param $requestedName
      * @param array|null $options
-     * @return Logger
+     * @return LoggerInterface
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \Psr\Container\NotFoundExceptionInterface
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): LoggerInterface
     {
-        $config   = $container->get('config');
+        $config = $container->get('config');
         $filename = $this->getLogFilename($config);
-        $writer   = new Stream($filename);
-        $logger   = new Logger();
-        $logger->addWriter($writer);
+
+        $logger = new Logger('cpms-client');
+        $logger->pushHandler(new StreamHandler($filename));
 
         return $logger;
     }

--- a/test/CpmsClientTest/Client/NotificationsClientTest.php
+++ b/test/CpmsClientTest/Client/NotificationsClientTest.php
@@ -80,12 +80,15 @@ class NotificationsClientTest extends TestCase
         $logDir = sys_get_temp_dir() . '/mot_logger_' . uniqid('', true);
         mkdir($logDir);
 
-        $logFile = $logDir . '/test.log';
+        $logFile = $logDir . '/cpms-client.log';
 
         $config = [
-            'logger' => [
+            'cpms_client'=> [
+                'logger' => [
                 'location' => $logDir,
-                'filename' => 'test.log',
+                'filename' => 'cpms-client.log',
+                'channel' => 'cpms-client',
+                ],
             ],
         ];
 
@@ -97,6 +100,8 @@ class NotificationsClientTest extends TestCase
             ->willReturn($config);
 
         $factory = new LoggerFactory();
+        
+        $this->assertSame($logFile, $factory->getLogFilename($config));
 
         $logger = $factory($container, LoggerFactory::DEFAULT_LOGGER_ALIAS);
 
@@ -123,9 +128,12 @@ class NotificationsClientTest extends TestCase
         mkdir($logDir);
 
         $config = [
-            'logger' => [
+               'cpms_client'=> [
+                'logger' => [
                 'location' => $logDir,
-                'filename' => 'test.log',
+                'filename' => 'cpms-client.log',
+                'channel' => 'cpms-client',
+                ],
             ],
         ];
 
@@ -158,6 +166,7 @@ class NotificationsClientTest extends TestCase
             'logger' => [
                 'location' => $logDir,
                 'filename' => 'test.log',
+                'channel' => 'cpms-client',
             ],
         ];
 

--- a/test/CpmsClientTest/Client/NotificationsClientTest.php
+++ b/test/CpmsClientTest/Client/NotificationsClientTest.php
@@ -10,7 +10,7 @@ use DVSA\CPMS\Notifications\Messages\Values\PaymentNotificationV1;
 use DVSA\CPMS\Queues\QueueAdapters\InMemory\InMemoryQueues;
 use DVSA\CPMS\Queues\QueueAdapters\Interfaces\Queues;
 use PHPUnit\Framework\TestCase;
-use Laminas\Log\Logger;
+use Psr\Log\LoggerInterface;
 use Laminas\Log\Writer\Mock as MockWriter;
 
 /**
@@ -64,9 +64,7 @@ class NotificationsClientTest extends TestCase
         //
         // we use ZF2's mock writer, so that the logger never attempts to
         // write either to disk nor to the screen
-        $logger = new Logger;
-        $mockWriter = new MockWriter;
-        $logger->addWriter($mockWriter);
+        $logger = $this->createMock(LoggerInterface::class);
 
         // finally!! we can build the client that we're unit testing here
         $unit = new NotificationsClient($queues, $logger);

--- a/test/CpmsClientTest/Client/NotificationsClientTest.php
+++ b/test/CpmsClientTest/Client/NotificationsClientTest.php
@@ -3,13 +3,17 @@
 namespace CpmsClientTest\Client;
 
 use CpmsClient\Client\NotificationsClient;
+use CpmsClient\Service\LoggerFactory;
 use DateTime;
 use DVSA\CPMS\Notifications\Ids\ValueBuilders\GenerateNotificationId;
 use DVSA\CPMS\Notifications\Messages\Maps\MapNotificationTypes;
 use DVSA\CPMS\Notifications\Messages\Values\PaymentNotificationV1;
 use DVSA\CPMS\Queues\QueueAdapters\InMemory\InMemoryQueues;
 use DVSA\CPMS\Queues\QueueAdapters\Interfaces\Queues;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -69,6 +73,108 @@ class NotificationsClientTest extends TestCase
         $unit = new NotificationsClient($queues, $logger);
 
         return $unit;
+    }
+
+    public function testLoggerWritesToConfiguredFilePath(): void
+    {
+        $logDir = sys_get_temp_dir() . '/mot_logger_' . uniqid('', true);
+        mkdir($logDir);
+
+        $logFile = $logDir . '/test.log';
+
+        $config = [
+            'logger' => [
+                'location' => $logDir,
+                'filename' => 'test.log',
+            ],
+        ];
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with('config')
+            ->willReturn($config);
+
+        $factory = new LoggerFactory();
+
+        $logger = $factory($container, LoggerFactory::DEFAULT_LOGGER_ALIAS);
+
+        $this->assertInstanceOf(LoggerInterface::class, $logger);
+        $this->assertInstanceOf(Logger::class, $logger);
+
+        $logger->info('Test log message');
+
+        $this->assertFileExists($logFile);
+
+        $contents = file_get_contents($logFile);
+
+        $this->assertIsString($contents);
+        $this->assertStringContainsString('Test log message', $contents);
+        $this->assertStringContainsString('cpms-client', $contents);
+
+        @unlink($logFile);
+        @rmdir($logDir);
+    }
+
+    public function testFactoryConfiguresStreamHandler(): void
+    {
+        $logDir = sys_get_temp_dir() . '/mot_logger_' . uniqid('', true);
+        mkdir($logDir);
+
+        $config = [
+            'logger' => [
+                'location' => $logDir,
+                'filename' => 'test.log',
+            ],
+        ];
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->method('get')
+            ->with('config')
+            ->willReturn($config);
+
+        $factory = new LoggerFactory();
+
+        $logger = $factory($container, LoggerFactory::DEFAULT_LOGGER_ALIAS);
+
+        $this->assertInstanceOf(Logger::class, $logger);
+
+        $handlers = $logger->getHandlers();
+
+        $this->assertNotEmpty($handlers);
+        $this->assertInstanceOf(StreamHandler::class, $handlers[0]);
+
+        @rmdir($logDir);
+    }
+
+    public function testLoggerChannelIsConfigured(): void
+    {
+        $logDir = sys_get_temp_dir() . '/mot_logger_' . uniqid('', true);
+        mkdir($logDir);
+
+        $config = [
+            'logger' => [
+                'location' => $logDir,
+                'filename' => 'test.log',
+            ],
+        ];
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->method('get')
+            ->with('config')
+            ->willReturn($config);
+
+        $factory = new LoggerFactory();
+
+        $logger = $factory($container, LoggerFactory::DEFAULT_LOGGER_ALIAS);
+
+        $this->assertInstanceOf(Logger::class, $logger);
+        $this->assertSame('cpms-client', $logger->getName());
+
+        @rmdir($logDir);
     }
 
     /**

--- a/test/CpmsClientTest/Client/NotificationsClientTest.php
+++ b/test/CpmsClientTest/Client/NotificationsClientTest.php
@@ -11,7 +11,6 @@ use DVSA\CPMS\Queues\QueueAdapters\InMemory\InMemoryQueues;
 use DVSA\CPMS\Queues\QueueAdapters\Interfaces\Queues;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Laminas\Log\Writer\Mock as MockWriter;
 
 /**
  * @coversDefaultClass CpmsClient\Client\NotificationsClient

--- a/test/CpmsClientTest/MockLogger.php
+++ b/test/CpmsClientTest/MockLogger.php
@@ -1,38 +1,59 @@
-<?php namespace CpmsClientTest;
+<?php
 
-use Laminas\Log\LoggerInterface;
+namespace CpmsClientTest;
+
+use Psr\Log\LoggerInterface;
 
 class MockLogger implements LoggerInterface
 {
-    public function emerg($message, $extra = [])
+    public array $logs = [];
+
+    public function emergency(string|\Stringable $message, array $context = []): void
     {
+        $this->log('emergency', $message, $context);
     }
 
-    public function alert($message, $extra = [])
+    public function alert(string|\Stringable $message, array $context = []): void
     {
+        $this->log('alert', $message, $context);
     }
 
-    public function crit($message, $extra = [])
+    public function critical(string|\Stringable $message, array $context = []): void
     {
+        $this->log('critical', $message, $context);
     }
 
-    public function err($message, $extra = [])
+    public function error(string|\Stringable $message, array $context = []): void
     {
+        $this->log('error', $message, $context);
     }
 
-    public function warn($message, $extra = [])
+    public function warning(string|\Stringable $message, array $context = []): void
     {
+        $this->log('warning', $message, $context);
     }
 
-    public function notice($message, $extra = [])
+    public function notice(string|\Stringable $message, array $context = []): void
     {
+        $this->log('notice', $message, $context);
     }
 
-    public function info($message, $extra = [])
+    public function info(string|\Stringable $message, array $context = []): void
     {
+        $this->log('info', $message, $context);
     }
 
-    public function debug($message, $extra = [])
+    public function debug(string|\Stringable $message, array $context = []): void
     {
+        $this->log('debug', $message, $context);
+    }
+
+    public function log($level, string|\Stringable $message, array $context = []): void
+    {
+        $this->logs[] = [
+            'level' => $level,
+            'message' => (string) $message,
+            'context' => $context,
+        ];
     }
 }

--- a/test/CpmsClientTest/Service/ApiServiceTest.php
+++ b/test/CpmsClientTest/Service/ApiServiceTest.php
@@ -55,8 +55,16 @@ class ApiServiceTest extends AbstractHttpControllerTestCase
         $loader = $this->getApplicationServiceLocator()->get('ControllerManager');
         /** @var SampleController $controller */
         $controller = $loader->get('CpmsClientTest\Sample');
-        $plugin     = $controller->getCpmsRestClient();
-        $this->assertInstanceOf('CpmsClient\Service\ApiService', $plugin);
+        $plugin = $controller->plugin('getCpmsRestClient');
+        $this->assertInstanceOf(
+            \CpmsClient\Controller\Plugin\GetRestClient::class,
+            $plugin
+        );
+        // $service = $plugin();
+        // $this->assertInstanceOf(
+        //     \CpmsClient\Service\ApiService::class,
+        //     $service
+        // );
     }
 
     /**

--- a/test/CpmsClientTest/Service/ApiServiceTest.php
+++ b/test/CpmsClientTest/Service/ApiServiceTest.php
@@ -55,16 +55,8 @@ class ApiServiceTest extends AbstractHttpControllerTestCase
         $loader = $this->getApplicationServiceLocator()->get('ControllerManager');
         /** @var SampleController $controller */
         $controller = $loader->get('CpmsClientTest\Sample');
-        $plugin = $controller->plugin('getCpmsRestClient');
-        $this->assertInstanceOf(
-            \CpmsClient\Controller\Plugin\GetRestClient::class,
-            $plugin
-        );
-        // $service = $plugin();
-        // $this->assertInstanceOf(
-        //     \CpmsClient\Service\ApiService::class,
-        //     $service
-        // );
+        $plugin     = $controller->getCpmsRestClient();
+        $this->assertInstanceOf('CpmsClient\Service\ApiService', $plugin);
     }
 
     /**


### PR DESCRIPTION
## Description
Have remove all instances of laminas logging and refactored to work with dvsa logger, have done a regressive search of code bas and no longer find any calls to laminas logger, removed laminas/laminas-dependency-plugin as no longer required or used. Ensured that composer test passes cleanly.
<!--
Include a summary of the change here.
-->

Related issue: [BL-21719](https://dvsa.atlassian.net/browse/BL-21719)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code?
- [ ] Have you have added tests that prove the fix or feature is effective and working?
- [x] Did you make sure to update any documentation relating to this change?

<img width="578" height="355" alt="Screenshot 2026-06-22 at 15 52 47" src="https://github.com/user-attachments/assets/636ceeef-12fe-4b6e-b5fe-a7e632fa8cdb" />

[BL-21950]: https://dvsa.atlassian.net/browse/BL-21950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[BL-21719]: https://dvsa.atlassian.net/browse/BL-21719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ